### PR TITLE
Fix the Errorf statements

### DIFF
--- a/resource_dns_record.go
+++ b/resource_dns_record.go
@@ -118,7 +118,7 @@ func resourceDomainRecordRead(d *schema.ResourceData, meta interface{}) error {
 	log.Println("Fetching", domain, "records...")
 	records, err := client.GetDomainRecords(customer, domain)
 	if err != nil {
-		return fmt.Errorf("couldn't find domain record: ", err.Error())
+		return fmt.Errorf("couldn't find domain record (%s): %s", domain, err.Error())
 	}
 
 	return populateResourceDataFromResponse(records, d)
@@ -161,7 +161,7 @@ func populateDomainInfo(client *GoDaddyClient, r *domainRecordResource, d *schem
 	log.Println("Fetching", r.Domain, "info...")
 	domain, err = client.GetDomain(r.Customer, r.Domain)
 	if err != nil {
-		return fmt.Errorf("couldn't find domain: ", err.Error())
+		return fmt.Errorf("couldn't find domain (%s): %s", r.Domain, err.Error())
 	}
 
 	d.SetId(strconv.FormatInt(domain.ID, 10))


### PR DESCRIPTION
The Errorf statements were missing the `%s` and was outputting errors that looked like this:

```
* godaddy_domain_record.main: couldn't find domain record: %!(EXTRA string=[404:UNKNOWN_DOMAIN] The given domain is not registered, or does not have a zone file)
```

I also dumped the domain name into the error logs. I can remove that if needed. I could not get the debug info from the `log.Println()` statements when running directly from Terraform.