### PR TITLE
Changed environment variables to match TF ACME provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ bash <(curl -s https://raw.githubusercontent.com/n3integration/terraform-godaddy
 In order to leverage the GoDaddy APIs, an [API key](https://developer.godaddy.com/keys/) is required. The key pair can be optionally stored in environment variables.
 
 ```bash
-export GD_KEY=abc
-export GD_SECRET=123
+export GODADDY_API_KEY=abc
+export GODADDY_API_SECRET=123
 ```
 
 ## Provider
 
-If `key` and `secret` aren't provided under the `godaddy` `provider`, they are expected to be exposed as environment variables: `GD_KEY` and `GD_SECRET`.
+If `key` and `secret` aren't provided under the `godaddy` `provider`, they are expected to be exposed as environment variables: `GODADDY_API_KEY` and `GODADDY_API_SECRET`.
 
 ```terraform
 provider "godaddy" {

--- a/client_test.go
+++ b/client_test.go
@@ -13,8 +13,8 @@ import (
 var key, secret, baseURL string
 
 func init() {
-	key = os.Getenv("GD_KEY")
-	secret = os.Getenv("GD_SECRET")
+	key = os.Getenv("GODADDY_API_KEY")
+	secret = os.Getenv("GODADDY_API_SECRET")
 	baseURL = "https://api.godaddy.com"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version=1.4.2
+version=1.5.0
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 mach=$(uname -m)

--- a/provider.go
+++ b/provider.go
@@ -12,14 +12,14 @@ func Provider() terraform.ResourceProvider {
 			"key": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GD_KEY", nil),
+				DefaultFunc: schema.EnvDefaultFunc("GODADDY_API_KEY", nil),
 				Description: "GoDaddy API Key.",
 			},
 
 			"secret": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GD_SECRET", nil),
+				DefaultFunc: schema.EnvDefaultFunc("GODADDY_API_SECRET", nil),
 				Description: "GoDaddy API Secret.",
 			},
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -30,9 +30,9 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	verifyEnvExists(t, "GD_KEY")
-	verifyEnvExists(t, "GD_SECRET")
-	verifyEnvExists(t, "GD_DOMAIN")
+	verifyEnvExists(t, "GODADDY_API_KEY")
+	verifyEnvExists(t, "GODADDY_API_SECRET")
+	verifyEnvExists(t, "GODADDY_DOMAIN")
 }
 
 func verifyEnvExists(t *testing.T, key string) {


### PR DESCRIPTION
Hi,
This just changes the GD_KEY & GD_SECRET environment variables to GODADDY_API_KEY & GODADDY_API_SECRET as this seems to be the standard convention in most other projects (e.g [lego](https://github.com/xenolf/lego) and the [TF ACME Provider](https://github.com/paybyphone/terraform-provider-acme) which uses lego.)

Cheers