### PR TITLE
#18 - godaddy_domain_record.mydomain: data must be between 1..255 cha…

### DIFF
--- a/client.go
+++ b/client.go
@@ -205,7 +205,7 @@ func validate(resp *http.Response) error {
 		return err
 	}
 
-	return fmt.Errorf("[%d:%s] %s", resp.StatusCode, errResp.Code, errResp.Message)
+	return fmt.Errorf("[%d:%s] %s %s", resp.StatusCode, errResp.Code, errResp.Message, body)
 }
 
 func formatURL(baseURL string) (string, error) {

--- a/types.go
+++ b/types.go
@@ -65,8 +65,14 @@ type DomainRecord struct {
 func NewDomainRecord(name, t, data string, ttl int) (*DomainRecord, error) {
 	name = strings.TrimSpace(name)
 	data = strings.TrimSpace(data)
-	if err := ValidateData(data); err != nil {
-		return nil, err
+	if t == "SOA" {
+        if err := ValidateSOAData(data); err != nil {
+            return nil, err
+        }
+	} else {
+        if err := ValidateData(data); err != nil {
+            return nil, err
+	    }
 	}
 	parts := strings.Split(name, ".")
 	if len(parts) < 1 || len(parts) > 255 {
@@ -105,6 +111,14 @@ func NewARecord(data string) (*DomainRecord, error) {
 func ValidateData(data string) error {
 	if len(data) < 1 || len(data) > 255 {
 		return fmt.Errorf("data must be between 1..255 characters in length")
+	}
+	return nil
+}
+
+// ValidateSOAData performs bounds checking on a data element if record type is SOA
+func ValidateSOAData(data string) error {
+	if len(data) != 0 {
+		return fmt.Errorf("data must be 0 characters in length if the record type is SOA")
 	}
 	return nil
 }


### PR DESCRIPTION
…racters in length

 - changed `godaddy_domain_record.record.data` validation if type is SOA (`data` must be an empty string)
 - if the GoDaddy API returns an an actual error, we log out the whole message body

The logging change is "bad", but it is definitely better than nothing. The problem is that `errResp.Code` and `errResp.Message` are now duplicates, but I cannot fix this (at least right now, this is the first time I touch Go code).
To have an idea what the issue can be, you need at least the `field`.