### PR TITLE
supports mx records by adding priority option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ provider "godaddy" {
 ```
 
 ## Domain Record Resource
-A `godaddy_domain_record` resource requires a `domain`. If the domain is not registered under the account that owns the key, an optional `customer` number can be specified. 
-Additionally, one or more `record` instances are required. For each `record`, the `name`, `type`, and `data` attributes are required. Address and NameServer records can be 
-defined using shorthand-notation as `addresses = [""]` or `nameservers = [""]`, respectively unless you need to override the default time-to-live (3600). The available record 
+A `godaddy_domain_record` resource requires a `domain`. If the domain is not registered under the account that owns the key, an optional `customer` number can be specified.
+Additionally, one or more `record` instances are required. For each `record`, the `name`, `type`, and `data` attributes are required. `MX` records can optionally specify `priority` or will default to `0`. Address and NameServer records can be
+defined using shorthand-notation as `addresses = [""]` or `nameservers = [""]`, respectively unless you need to override the default time-to-live (3600). The available record
 types include:
 
 * A
 * AAAA
 * CNAME
+* MX
 * NS
 * SOA
 * TXT
@@ -64,6 +65,14 @@ resource "godaddy_domain_record" "gd-fancy-domain" {
     type = "CNAME"
     data = "fancy.github.io"
     ttl = 3600
+  }
+
+  record {
+    name = "@"
+    type = "MX"
+    data = "aspmx.l.google.com."
+    ttl = 600
+    priority = 1
   }
 
   addresses   = ["192.168.1.2", "192.168.1.3"]

--- a/resource_dns_record.go
+++ b/resource_dns_record.go
@@ -54,7 +54,8 @@ func newDomainRecordResource(d *schema.ResourceData) (domainRecordResource, erro
 				data["name"].(string),
 				data["type"].(string),
 				data["data"].(string),
-				data["ttl"].(int))
+				data["ttl"].(int),
+				data["priority"].(int))
 
 			if err != nil {
 				return r, err
@@ -151,6 +152,11 @@ func resourceDomainRecord() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  DefaultTTL,
+						},
+						"priority": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  DefaultPriority,
 						},
 					},
 				},
@@ -254,6 +260,7 @@ func flattenRecords(list []*DomainRecord) []map[string]interface{} {
 			"type": r.Type,
 			"data": r.Data,
 			"ttl":  r.TTL,
+			"priority": r.Priority,
 		}
 		result = append(result, l)
 	}

--- a/types.go
+++ b/types.go
@@ -32,6 +32,7 @@ const (
 
 const (
 	DefaultTTL = 3600
+	DefaultPriority = 0
 
 	StatusActive    = "ACTIVE"
 	StatusCancelled = "CANCELLED"
@@ -62,7 +63,7 @@ type DomainRecord struct {
 }
 
 // NewDomainRecord validates and constructs a DomainRecord, if valid.
-func NewDomainRecord(name, t, data string, ttl int) (*DomainRecord, error) {
+func NewDomainRecord(name, t, data string, ttl int, priority int) (*DomainRecord, error) {
 	name = strings.TrimSpace(name)
 	data = strings.TrimSpace(data)
 	if err := ValidateData(data); err != nil {
@@ -80,6 +81,9 @@ func NewDomainRecord(name, t, data string, ttl int) (*DomainRecord, error) {
 	if ttl < 0 {
 		return nil, fmt.Errorf("ttl must be a positive value")
 	}
+	if err := ValidatePriority(priority); err != nil {
+		return nil, err
+	}
 	if !isSupportedType(t) {
 		return nil, fmt.Errorf("type must be one of: %s", supportedTypes)
 	}
@@ -88,23 +92,32 @@ func NewDomainRecord(name, t, data string, ttl int) (*DomainRecord, error) {
 		Type: t,
 		Data: data,
 		TTL:  ttl,
+		Priority: priority,
 	}, nil
 }
 
 // NewNSRecord constructs a nameserver record from the supplied data
 func NewNSRecord(data string) (*DomainRecord, error) {
-	return NewDomainRecord("@", "NS", data, DefaultTTL)
+	return NewDomainRecord("@", "NS", data, DefaultTTL, DefaultPriority)
 }
 
 // NewARecord constructs a new address record from the supplied data
 func NewARecord(data string) (*DomainRecord, error) {
-	return NewDomainRecord("@", "A", data, DefaultTTL)
+	return NewDomainRecord("@", "A", data, DefaultTTL, DefaultPriority)
 }
 
 // ValidateData performs bounds checking on a data element
 func ValidateData(data string) error {
 	if len(data) < 0 || len(data) > 255 {
 		return fmt.Errorf("data must be between 0..255 characters in length")
+	}
+	return nil
+}
+
+// ValidatePriority performs bounds checking on priority element
+func ValidatePriority(priority int) error {
+	if priority < 0 || priority > 65535 {
+		return fmt.Errorf("priority must be between 0..65535 (16 bit)")
 	}
 	return nil
 }


### PR DESCRIPTION
Adds MX record support by including `priority` option.

Also gives an example of `MX` record being created with specific `priority`.