### PR TITLE
easy binary builds with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# ==================== [START] Global Variable Declaration =================== #
+SHELL := /bin/bash
+# 'shell' removes newlines
+BASE_DIR := $(shell pwd)
+
+UNAME_S := $(shell uname -s)
+
+# exports all variables
+export
+# ===================== [END] Global Variable Declaration ==================== #
+
+build:
+	@docker-compose -f "${BASE_DIR}/docker/docker-compose.yml" run builder

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ provider "godaddy" {
 ```
 
 ## Domain Record Resource
-A `godaddy_domain_record` resource requires a `domain`. If the domain is not registered under the account that owns the key, an optional `customer` number can be specified. 
-Additionally, one or more `record` instances are required. For each `record`, the `name`, `type`, and `data` attributes are required. Address and NameServer records can be 
-defined using shorthand-notation as `addresses = [""]` or `nameservers = [""]`, respectively unless you need to override the default time-to-live (3600). The available record 
+A `godaddy_domain_record` resource requires a `domain`. If the domain is not registered under the account that owns the key, an optional `customer` number can be specified.
+Additionally, one or more `record` instances are required. For each `record`, the `name`, `type`, and `data` attributes are required. Address and NameServer records can be
+defined using shorthand-notation as `addresses = [""]` or `nameservers = [""]`, respectively unless you need to override the default time-to-live (3600). The available record
 types include:
 
 * A
@@ -78,6 +78,12 @@ This plugin also supports Terraform's [import](https://www.terraform.io/docs/imp
 through `terraform plan` and update the resource configuration accordingly to preserve existing data. The supplied resource `id` to the `terraform import` command should
 be the name of the domain that you would like to import. Although this is currently a manual workaround, this plugin will be updated when Terraform includes support for
 fully automated imports.
+
+## Building the binary with Docker Compose
+
+A [Makefile](Makefile) has been provided to make it easier to develop on this repository.
+
+Run `make build` in order to mount the code into a [golang](https://hub.docker.com/_/golang/) container that's been extended to include [glide](https://github.com/Masterminds/glide). This will output a `terraform-godaddy` binary built for Linux in the root of the project directory.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,13 @@ provider "godaddy" {
 ```
 
 ## Domain Record Resource
-A `godaddy_domain_record` resource requires a `domain`. If the domain is not registered under the account that owns the key, an optional `customer` number can be specified.
-Additionally, one or more `record` instances are required. For each `record`, the `name`, `type`, and `data` attributes are required. Address and NameServer records can be
-defined using shorthand-notation as `addresses = [""]` or `nameservers = [""]`, respectively unless you need to override the default time-to-live (3600). The available record
-types include:
+
+A `godaddy_domain_record` resource requires a `domain`. If the domain is not registered under the account that owns the key, an optional `customer` number can be specified. Additionally, one or more `record` instances are required. For each `record`, the `name`, `type`, and `data` attributes are required. `MX` records can optionally specify `priority` or will default to `0`. Address and NameServer records can be defined using shorthand-notation as `addresses = [""]` or `nameservers = [""]`, respectively unless you need to override the default time-to-live (3600). The available record types include:
 
 * A
 * AAAA
 * CNAME
+* MX
 * NS
 * SOA
 * TXT
@@ -64,6 +63,14 @@ resource "godaddy_domain_record" "gd-fancy-domain" {
     type = "CNAME"
     data = "fancy.github.io"
     ttl = 3600
+  }
+
+  record {
+    name = "@"
+    type = "MX"
+    data = "aspmx.l.google.com."
+    ttl = 600
+    priority = 1
   }
 
   addresses   = ["192.168.1.2", "192.168.1.3"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.9.7-stretch
+
+RUN curl -Lo /tmp/glide-install.sh https://glide.sh/get \
+ && chmod a+x /tmp/glide-install.sh \
+ && /tmp/glide-install.sh \
+ && rm -rf /tmp/glide-install.sh
+
+WORKDIR /go/src/github.com/n3integration/terraform-godaddy
+
+CMD glide install \
+ && go build -v .

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  builder:
+    container_name: godaddy-provider-builder
+    hostname: godaddy-provider-builder
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    restart: "no"
+    volumes:
+    - ..:/go/src/github.com/n3integration/terraform-godaddy

--- a/resource_dns_record.go
+++ b/resource_dns_record.go
@@ -54,7 +54,8 @@ func newDomainRecordResource(d *schema.ResourceData) (domainRecordResource, erro
 				data["name"].(string),
 				data["type"].(string),
 				data["data"].(string),
-				data["ttl"].(int))
+				data["ttl"].(int),
+				data["priority"].(int))
 
 			if err != nil {
 				return r, err
@@ -151,6 +152,11 @@ func resourceDomainRecord() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  DefaultTTL,
+						},
+						"priority": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  DefaultPriority,
 						},
 					},
 				},
@@ -254,6 +260,7 @@ func flattenRecords(list []*DomainRecord) []map[string]interface{} {
 			"type": r.Type,
 			"data": r.Data,
 			"ttl":  r.TTL,
+			"priority": r.Priority,
 		}
 		result = append(result, l)
 	}

--- a/types.go
+++ b/types.go
@@ -32,6 +32,7 @@ const (
 
 const (
 	DefaultTTL = 3600
+	DefaultPriority = 0
 
 	StatusActive    = "ACTIVE"
 	StatusCancelled = "CANCELLED"
@@ -62,7 +63,7 @@ type DomainRecord struct {
 }
 
 // NewDomainRecord validates and constructs a DomainRecord, if valid.
-func NewDomainRecord(name, t, data string, ttl int) (*DomainRecord, error) {
+func NewDomainRecord(name, t, data string, ttl int, priority int) (*DomainRecord, error) {
 	name = strings.TrimSpace(name)
 	data = strings.TrimSpace(data)
 	if err := ValidateData(data); err != nil {
@@ -80,6 +81,9 @@ func NewDomainRecord(name, t, data string, ttl int) (*DomainRecord, error) {
 	if ttl < 0 {
 		return nil, fmt.Errorf("ttl must be a positive value")
 	}
+	if err := ValidatePriority(priority); err != nil {
+		return nil, err
+	}
 	if !isSupportedType(t) {
 		return nil, fmt.Errorf("type must be one of: %s", supportedTypes)
 	}
@@ -88,23 +92,32 @@ func NewDomainRecord(name, t, data string, ttl int) (*DomainRecord, error) {
 		Type: t,
 		Data: data,
 		TTL:  ttl,
+		Priority: priority,
 	}, nil
 }
 
 // NewNSRecord constructs a nameserver record from the supplied data
 func NewNSRecord(data string) (*DomainRecord, error) {
-	return NewDomainRecord("@", "NS", data, DefaultTTL)
+	return NewDomainRecord("@", "NS", data, DefaultTTL, DefaultPriority)
 }
 
 // NewARecord constructs a new address record from the supplied data
 func NewARecord(data string) (*DomainRecord, error) {
-	return NewDomainRecord("@", "A", data, DefaultTTL)
+	return NewDomainRecord("@", "A", data, DefaultTTL, DefaultPriority)
 }
 
 // ValidateData performs bounds checking on a data element
 func ValidateData(data string) error {
 	if len(data) < 0 || len(data) > 255 {
 		return fmt.Errorf("data must be between 0..255 characters in length")
+	}
+	return nil
+}
+
+// ValidatePriority performs bounds checking on priority element
+func ValidatePriority(priority int) error {
+	if priority < 0 || priority > 65535 {
+		return fmt.Errorf("priority must be between 0..65535 (16 bit)")
 	}
 	return nil
 }


### PR DESCRIPTION
Provides `Makefile`, `Dockerfile` and `docker-compose.yml` files allowing a binary to be built just by running `make build` with nothing but `docker` and `docker-compose` installed.

Built provider binary outputs to `terraform-godaddy`.