### PR TITLE
Increase record data length restriction to accommodate DKIM RSA keys

### DIFF
--- a/types.go
+++ b/types.go
@@ -108,7 +108,7 @@ func NewARecord(data string) (*DomainRecord, error) {
 
 // ValidateData performs bounds checking on a data element
 func ValidateData(data string) error {
-	if len(data) < 0 || len(data) > 255 {
+	if len(data) < 0 || len(data) > 8192 {
 		return fmt.Errorf("data must be between 0..255 characters in length")
 	}
 	return nil

--- a/types.go
+++ b/types.go
@@ -109,7 +109,7 @@ func NewARecord(data string) (*DomainRecord, error) {
 // ValidateData performs bounds checking on a data element
 func ValidateData(data string) error {
 	if len(data) < 0 || len(data) > 8192 {
-		return fmt.Errorf("data must be between 0..255 characters in length")
+		return fmt.Errorf("data must be between 0..8192 characters in length")
 	}
 	return nil
 }

--- a/types_test.go
+++ b/types_test.go
@@ -2,7 +2,19 @@ package main
 
 import (
 	"testing"
+    "math/rand"
 )
+
+
+func randBinaryString(n int) string {
+    var binRunes = []rune("01")
+    out := make([]rune, n)
+    for i := range out {
+        out[i] = binRunes[rand.Intn(len(binRunes))]
+    }
+    return string(out)
+}
+
 
 func TestNewDomainRecord(t *testing.T) {
 	var criteria = []struct {
@@ -13,7 +25,7 @@ func TestNewDomainRecord(t *testing.T) {
 		{"Given a valid domain", "godaddy.com", false},
 		{"Given a domain without a TLD", "localhost", false},
 		{"Given an empty domain", "", true},
-		{"Given a long name", "Lopado­temacho­selacho­galeo­kranio­leipsano­drim­hypo­trimmato­silphio­parao­melito­katakechy­meno­kichl­epi­kossypho­phatto­perister­alektryon­opte­kephallio­kigklo­peleio­lagoio­siraio­baphe­tragano­pterygon", true},
+		{"Given a long name", randBinaryString(8193), true},
 	}
 	for _, test := range criteria {
 		t.Run(test.Name, func(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"testing"
-    "math/rand"
+        "math/rand"
 )
 
 

--- a/types_test.go
+++ b/types_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"testing"
-        "math/rand"
+	"math/rand"
 )
 
 


### PR DESCRIPTION
Current data length restrictions are too low to accommodate for DKIM RSA public keys on TXT records, so I raised the limit to 8192 runes.

For me 8192 works, but you may have some reasoning to have set it to a higher or lower value, so I leave that to your discretion -- just bear in mind many people will need to have long RSA keys on these TXT records.